### PR TITLE
Add commit-by-commit refactor summary since Jan 12 baseline

### DIFF
--- a/refactor_branch_changes_working.md
+++ b/refactor_branch_changes_working.md
@@ -1,0 +1,97 @@
+# Refactor branch change log (working notes)
+
+## Branch checkout status
+- No separate local or remote branch matching `*refactor*` was available in this clone after `git fetch --all --prune`.
+- Analysis was performed on the current branch `work` at `HEAD` (`1a288fe`), which contains the recent refactor commits.
+
+## Reference point commit (Jan 12, 2026)
+### `0f396853fd2c3867e4b1565fb745a4c0a6674944` — `update modules`
+- Scope: `multiplex_model/modules.py` only.
+- Diff size: **33 insertions**, **9 deletions**.
+- Short summary: targeted updates to the monolithic modules implementation before the larger Jan/Feb refactor split.
+
+## Commits since `0f39685` (oldest -> newest)
+
+### `a63edc4` (2026-01-31) — `major refactor`
+- Converted utility code from single file layout into package modules:
+  - removed `multiplex_model/utils.py`
+  - introduced `multiplex_model/utils/{__init__,configuration,masking,optim,train_logging}.py`
+- Reworked core training/model files (`train_masked_model.py`, `multiplex_model/data.py`, `multiplex_model/modules.py`, `multiplex_model/losses.py`).
+- Added project metadata/build config in `pyproject.toml` and removed `requirements.txt`.
+- Removed `configs/cell_hierarchy.yaml` and `configs/celltypes_tokenizer.yaml`.
+- Net effect: very large architectural reorganization (**1366 insertions / 1415 deletions**).
+
+### `497b099` (2026-01-31) — `Formatting`
+- Follow-up formatting/readability pass across refactored files.
+- Heavy edits in `configuration.py`, plus cleanup in data/modules/training scripts.
+
+### `b5d664f` (2026-01-31) — `Fix config`
+- Simplified configuration handling; updated `train_masked_config.yaml` and associated training usage.
+- Removed now-unneeded config code paths.
+
+### `9d320b9` (2026-01-31) — `Cleaning`
+- Additional configuration/API cleanup and import pruning in utils and training entrypoint.
+
+### `e1aeff7` (2026-01-31) — `fix`
+- Small one-line deletion in `train_masked_model.py`.
+
+### `a54125f` (2026-01-31) — `fix config`
+- Further config normalization in `multiplex_model/utils/configuration.py`.
+
+### `9eb0d72` (2026-01-31) — `change logging`
+- Logging behavior and interfaces adjusted across:
+  - `multiplex_model/utils/train_logging.py`
+  - config plumbing and training script integration
+- Minor pyproject/config updates to align with logging changes.
+
+### `82993f3` (2026-01-31) — `Cleaning`
+- Removed dead code in `losses.py`.
+- Expanded/cleaned training logging logic and associated training script calls.
+
+### `de7997e` (2026-01-31) — `Cleaning`
+- Small polish pass in `train_logging.py`.
+
+### `c59d17a` (2026-01-31) — `Adjust logging`
+- Significant logging improvements in `train_logging.py` (**64 insertions**): likely richer metrics/log structures.
+
+### `3233543` (2026-01-31) — `Cleaning`
+- Minor logging cleanup in `train_logging.py`.
+
+### `0860e2a` (2026-02-02) — `fixes`
+- Small correctness fixes in config handling and training script.
+
+### `0388401` (2026-02-02) — `minor fix`
+- Single-line fix in `train_masked_model.py`.
+
+### `ecbfee9` (2026-02-02) — `logging cleaning`
+- Broader cleanup/refinement of training-time logging flow in `train_masked_model.py`.
+
+### `62bca08` (2026-02-07) — `refactor`
+- Large module-system refactor: replaced monolithic model-module design with package-based architecture under `multiplex_model/modules/`.
+- Added model backbone implementations and registry structure:
+  - `base_modules.py`, `registry.py`, `resnet.py`, `swin.py`, `vit.py`, `convext.py`, `immuvis.py`
+- Added new training configs:
+  - `configs/train_swin_config.yaml`
+  - `configs/train_vit_config.yaml`
+- Updated data/config/logging integration for new module organization.
+- Net effect: biggest expansion in this period (**1838 insertions / 72 deletions**).
+
+### `88cc123` (2026-02-07) — `refactor`
+- Follow-up adjustments for new module framework:
+  - `immuvis.py` updates
+  - extra config hooks
+  - training script wiring fixes
+
+### `f670f4d` (2026-02-11) — `Cleaning`
+- Removed legacy monolithic `multiplex_model/modules.py` (590-line deletion), finalizing migration to package modules.
+- Added `.gitignore` updates.
+
+### `1a288fe` (2026-02-11) — `set latent norm as default`
+- Default configuration changed to enable/select latent norm in `configuration.py`.
+
+## High-level summary of what changed since Jan 12 commit
+- **Architecture**: transitioned from monolithic module/util files to package-oriented structure for both model components and utilities.
+- **Backbone support**: introduced modular backbone implementations (ResNet, Swin, ViT, ConvNeXt, ImmuVis) and module registry wiring.
+- **Configuration system**: iteratively cleaned and stabilized config loading/validation and default behaviors.
+- **Training/logging**: repeated logging refactors and cleanup improved instrumentation and training integration.
+- **Project structure**: moved toward `pyproject.toml` workflow and removed legacy requirements file.

--- a/training_impact_changes_since_0f39685.md
+++ b/training_impact_changes_since_0f39685.md
@@ -1,0 +1,192 @@
+# Training-impacting changes since `0f396853fd2c3867e4b1565fb745a4c0a6674944`
+
+This note focuses only on changes that *practically alter model training behavior* (optimization dynamics, model capacity, masking objective, evaluation signals), rather than repository structure alone.
+
+## 0) Baseline (`0f39685`, Jan 12) in one line
+The Jan 12 `update modules` commit was a targeted update in the old monolithic `multiplex_model/modules.py`; the later refactor period changed the training pipeline much more deeply (config validation, modular backbones, masking/loss flow, logging/eval metrics).
+
+---
+
+## 1) Latent normalization is now defaulted on (direct effect on latent scale/stability)
+**Practical impact:** latent activations entering the decoder are now normalized by default, which usually stabilizes optimization and can change reconstruction quality/calibration.
+
+- Config default is now `use_latent_norm=True` in encoder config.
+- The encoder applies `LayerNorm` on latent only if enabled.
+
+```python
+# multiplex_model/utils/configuration.py
+use_latent_norm: bool = Field(default=True)
+```
+
+```python
+# multiplex_model/modules/immuvis.py
+self.latent_norm = (
+    LayerNorm(pm_embedding_dims[-1], data_format="channels_first")
+    if use_latent_norm
+    else nn.Identity()
+)
+...
+x = self.latent_norm(x)
+```
+
+Why this matters for training:
+- Normalized latent distributions reduce scale drift across batches/panels.
+- Interacts with AdamW + cosine schedule by making effective step sizes less erratic.
+
+---
+
+## 2) Encoder/decoder architecture is now registry-driven (backbone choice affects convergence/capacity)
+**Practical impact:** training can now swap ConvNeXt / ViT / Swin / ResNet style components by config rather than code edits. This changes inductive bias, parameterization, and GPU/memory profile.
+
+- Registry-based resolution selects block/encoder classes from config.
+- Package includes dedicated implementations for ConvNeXt, ViT, Swin, ResNet (+ multiplex-specific components).
+
+```python
+# multiplex_model/modules/registry.py
+cls = registry.get(config["type"])
+module_parameters = config.get("module_parameters", {})
+return cls(**module_parameters)
+```
+
+```python
+# multiplex_model/modules/immuvis.py
+block_cls = resolve_block_class(block_type)
+...
+self.decoder = nn.Sequential(*[block_cls(decoded_embed_dim, **block_kwargs) for _ in range(num_blocks)])
+```
+
+Why this matters for training:
+- Backbone swap changes optimization landscape and required hyperparameters.
+- Enables controlled experiments without code drift (fewer accidental implementation differences).
+
+---
+
+## 3) Masking objective is explicitly two-stage in train, one-stage in validation
+**Practical impact:** train-time corruption is stronger and more diverse than val-time corruption, which materially changes learned invariances.
+
+Train loop behavior:
+1. Optional random channel subset sampling.
+2. Full channel dropping on a subset.
+3. Spatial patch masking on remaining active channels.
+
+Validation behavior:
+- No channel subset sampling, only full channel masking + spatial masking.
+
+```python
+# train_masked_model.py (train)
+img, channel_ids, masked_img, active_channel_ids = apply_channel_masking(..., apply_channel_subset_sampling=True)
+masked_img, _ = apply_spatial_masking(masked_img, spatial_masking_ratio, mask_patch_size)
+```
+
+```python
+# train_masked_model.py (val)
+_, _, masked_img, active_channel_ids = apply_channel_masking(..., apply_channel_subset_sampling=False)
+masked_img, pixel_mask = apply_spatial_masking(masked_img, spatial_masking_ratio, mask_patch_size)
+```
+
+```python
+# multiplex_model/utils/masking.py
+num_sampled_channels = np.random.randint(min_channels, num_channels + 1)
+...
+num_channels_to_mask = np.random.randint(1, max_channels_to_mask + 1)
+```
+
+Why this matters for training:
+- Model is forced to reconstruct from both missing channels and missing pixels.
+- Changes effective task difficulty and signal-to-noise ratio per step.
+
+---
+
+## 4) Uncertainty-aware objective path is explicit (`mi`, `logvar`, beta-NLL) with clamped log-variance gradients
+**Practical impact:** model optimizes a probabilistic target (mean + variance) instead of only point estimates; this alters both gradients and calibration behavior.
+
+```python
+# train_masked_model.py
+output = model(masked_img, active_channel_ids, channel_ids)["output"]
+mi, logvar = output.unbind(dim=-1)
+mi = torch.sigmoid(mi)
+logvar = ClampWithGrad.apply(logvar, -15.0, 15.0)
+loss = beta_nll_loss(img, mi, logvar, beta=beta)
+```
+
+```python
+# multiplex_model/utils/optim.py
+class ClampWithGrad(torch.autograd.Function):
+    ...
+    return x.clamp(min_val, max_val)
+```
+
+Why this matters for training:
+- Predictive variance is learned jointly with reconstruction mean.
+- Clamping avoids unstable variance extremes while retaining smooth gradients outside clamp bounds.
+
+---
+
+## 5) Optimization mechanics tightened: AMP+bfloat16, grad accumulation, grad clipping, warmup+cosine annealing
+**Practical impact:** effective batch dynamics and LR trajectory are now more controlled and scalable.
+
+```python
+# train_masked_model.py
+with autocast(device_type="cuda", dtype=torch.bfloat16):
+    ...
+scaler.scale(loss / gradient_accumulation_steps).backward()
+...
+torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+scheduler.step()
+```
+
+```python
+# multiplex_model/utils/optim.py
+if current_step < num_warmup_steps: ...
+...
+return final_lr_mult + (1.0 - final_lr_mult) * 0.5 * (1.0 + cos(pi * progress))
+```
+
+Why this matters for training:
+- Mixed precision improves throughput; gradient scaling protects low-precision stability.
+- Warmup + cosine decay often reduces early divergence and improves late-stage fine-tuning.
+
+---
+
+## 6) Evaluation signals are richer: latent rank + variance/MAE correlation
+**Practical impact:** validation now tracks representation quality and uncertainty usefulness, not just reconstruction error.
+
+```python
+# train_masked_model.py
+rankme = RankMe(all_latents)
+variance_mae_corr = torch.corrcoef(
+    torch.stack([all_channel_variances.flatten(), all_channel_maes.flatten()])
+)[0, 1].item()
+```
+
+Why this matters for training decisions:
+- `latent_rankme` can reveal collapse/overcompression trends.
+- Variance-vs-error correlation indicates whether uncertainty estimates are informative.
+
+---
+
+## 7) Config validation is stricter (fewer silent bad runs)
+**Practical impact:** many invalid settings now fail fast at startup instead of producing misleading training runs.
+
+Examples:
+- Positive checks for block counts and embedding dims.
+- Enforced length match between `*_layers_blocks` and `*_embedding_dims`.
+- Pan-marker layers cannot be empty.
+
+```python
+# multiplex_model/utils/configuration.py
+if len(v) != len(blocks):
+    raise ValueError(...)
+...
+if len(v) == 0:
+    raise ValueError("pm_embedding_dims cannot be empty ...")
+```
+
+Why this matters for training:
+- Less wasted GPU time on malformed experiments.
+- Better reproducibility across runs/config files.
+
+---
+
+## Quick takeaway
+The most consequential practical shifts are: **(a)** default latent norm, **(b)** modular backbone selection, **(c)** stronger/more explicit masking curriculum, **(d)** uncertainty-aware beta-NLL training with stabilized log-variance, and **(e)** more controlled optimization + richer validation diagnostics.


### PR DESCRIPTION
### Motivation
- Provide a concise, commit-by-commit summary of the refactor work performed since the Jan 12 baseline "update modules" commit. 
- Capture the large architectural changes, module split, logging/config improvements, and new backbone implementations to aid reviewers and future maintenance.

### Description
- Add `refactor_branch_changes_working.md` containing a chronological summary of every commit since the Jan 12 baseline plus a short summary of the baseline itself. 
- The document highlights the move from monolithic files to package-based `multiplex_model/modules/` and `multiplex_model/utils/`, the addition of multiple backbone implementations, configuration and logging cleanups, and project packaging updates. 
- Note the analysis was performed on the current `work` branch because no separate `refactor` branch was present in this clone. 
- The new file was created in the repository and persisted as a working summary for reviewers. 

### Testing
- Ran repository inspection commands to build the report: `git fetch --all --prune`, `git branch -a -vv`, and `git log --oneline --decorate --date=short` which completed successfully. 
- Verified per-commit statistics with `git show --stat` for the baseline and subsequent commits which completed successfully. 
- Confirmed the generated file exists and contains the expected content with `wc -l refactor_branch_changes_working.md` and `sed -n '1,220p' refactor_branch_changes_working.md` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e51c1e848321a01f3f4aa8e721ba)